### PR TITLE
do authorization on local cluster before forward request

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -35,7 +35,6 @@ func main() {
 		// +kubebuilder:scaffold:resource-register
 		WithResource(&clusterv1alpha1.ClusterGateway{}).
 		WithLocalDebugExtension().
-		//DisableAuthorization().
 		ExposeLoopbackMasterClientConfig().
 		ExposeLoopbackAuthorizer().
 		WithoutEtcd().

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -35,8 +35,9 @@ func main() {
 		// +kubebuilder:scaffold:resource-register
 		WithResource(&clusterv1alpha1.ClusterGateway{}).
 		WithLocalDebugExtension().
-		DisableAuthorization().
+		//DisableAuthorization().
 		ExposeLoopbackMasterClientConfig().
+		ExposeLoopbackAuthorizer().
 		WithoutEtcd().
 		WithOptionsFns(func(options *builder.ServerOptions) *builder.ServerOptions {
 			if err := config.ValidateSecret(); err != nil {
@@ -53,6 +54,7 @@ func main() {
 	}
 	config.AddSecretFlags(cmd.Flags())
 	config.AddClusterProxyFlags(cmd.Flags())
+	config.AddProxyAuthorizationFlags(cmd.Flags())
 	cmd.Flags().BoolVarP(&options.OCMIntegration, "ocm-integration", "", false,
 		"Enabling OCM integration, reading cluster CA and api endpoint from managed "+
 			"cluster.")

--- a/pkg/apis/cluster/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/cluster/v1alpha1/clustergateway_proxy.go
@@ -112,7 +112,7 @@ func (c *ClusterGatewayProxy) Connect(ctx context.Context, id string, options ru
 	})
 	proxyReqInfo.Verb = reqInfo.Verb
 
-	if config.ProxyLocalAuthorization {
+	if config.AuthorizateProxySubpath {
 		user, _ := request.UserFrom(ctx)
 		var attr authorizer.Attributes
 		if proxyReqInfo.IsResourceRequest {

--- a/pkg/config/args_authorization.go
+++ b/pkg/config/args_authorization.go
@@ -1,0 +1,12 @@
+package config
+
+import (
+	"github.com/spf13/pflag"
+)
+
+var ProxyLocalAuthorization bool
+
+func AddProxyAuthorizationFlags(set *pflag.FlagSet) {
+	set.BoolVarP(&ProxyLocalAuthorization, "proxy-local-authorization", "", false,
+		"do authorization locally before proxy request")
+}

--- a/pkg/config/args_authorization.go
+++ b/pkg/config/args_authorization.go
@@ -4,9 +4,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var ProxyLocalAuthorization bool
+var AuthorizateProxySubpath bool
 
 func AddProxyAuthorizationFlags(set *pflag.FlagSet) {
-	set.BoolVarP(&ProxyLocalAuthorization, "proxy-local-authorization", "", false,
-		"do authorization locally before proxy request")
+	set.BoolVarP(&AuthorizateProxySubpath, "authorize-proxy-subpath", "", false,
+		"perform an additional delegated authorization against the hub cluster for the target proxying path when invoking clustergateway/proxy subresource")
 }


### PR DESCRIPTION
Today gateway using cluster credential to forward the request. In multiple tenants, it means all tenants will share same credential and permission to access the target cluster, it is a security risk.

In multiple clusters management, we can assume hub cluster and managed cluster have same structure, for example, create namespace1 for user1 with dev permission on hub cluster, multiple clusters management will create namespace1 on all managed cluster.

With this assumption, to fix the issue above, gateway could do authorization on hub cluster before forward the request, for example, if user1 wants to access namespace1 on managed cluster, then forward, but if user2 wants to access namespace1 on managed cluster, then reject.

feature flag - --proxy-local-authorization=true to enable the change, default is false