### PR TITLE
multicluster wrap add enhance roundtripper, support informer cache

### DIFF
--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -3,15 +3,22 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	multicluster "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/transport"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	controllers "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var kubeconfig string
@@ -49,6 +56,54 @@ func main() {
 				panic(err)
 			}
 			fmt.Printf("Controller-runtime client get default namespace: %v\n", ns)
+
+			//
+			// with enhance cluster gateway roundtripper
+			//
+
+			enCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+			if err != nil {
+				return err
+			}
+			enCfg.Wrap(multicluster.NewEnhanceClusterGatewayRoundTripper(clusterName).NewRoundTripper)
+
+			// Native kubernetes client informer
+			nativeClient = kubernetes.NewForConfigOrDie(enCfg)
+
+			sharedInformer := informers.NewSharedInformerFactory(nativeClient, 0)
+			podInformer := sharedInformer.Core().V1().Pods().Informer()
+
+			fmt.Printf("Native client cache pod info:\n")
+			podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{AddFunc: addFunc})
+
+			ctx, cancel := context.WithCancel(context.TODO())
+			go sharedInformer.Start(ctx.Done())
+			for !podInformer.HasSynced() {
+				time.Sleep(time.Millisecond * 100)
+			}
+			cancel()
+
+			// Controller-runtime client informer
+			s := runtime.NewScheme()
+			scheme.AddToScheme(s)
+
+			mgr, err := controllers.NewManager(enCfg, manager.Options{Scheme: s})
+
+			podInformer2, err := mgr.GetCache().GetInformer(context.TODO(), &corev1.Pod{})
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Controller-runtime cache pod info:\n")
+			podInformer2.AddEventHandler(cache.ResourceEventHandlerFuncs{AddFunc: addFunc})
+
+			ctx, cancel = context.WithCancel(context.TODO())
+			go mgr.Start(ctx)
+			for !podInformer2.HasSynced() {
+				time.Sleep(time.Millisecond * 100)
+			}
+			cancel()
+
 			return nil
 		},
 	}
@@ -58,5 +113,15 @@ func main() {
 
 	if err := cmd.Execute(); err != nil {
 		panic(err)
+	}
+}
+
+func addFunc(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if pod.Namespace == "kube-system" {
+		fmt.Printf("%s\t%s\t%s\t%s\n", pod.Namespace, pod.Name, pod.Status.PodIP, pod.Status.HostIP)
 	}
 }

--- a/pkg/apis/cluster/transport/enroundtripper.go
+++ b/pkg/apis/cluster/transport/enroundtripper.go
@@ -1,0 +1,30 @@
+package multicluster
+
+import "net/http"
+
+var _ EnhanceClusterGatewayRoundTripper = &enhanceClusterGatewayRoundTripper{}
+
+type EnhanceClusterGatewayRoundTripper interface {
+	http.RoundTripper
+
+	NewRoundTripper(delegate http.RoundTripper) http.RoundTripper
+}
+
+type enhanceClusterGatewayRoundTripper struct {
+	clusterName string
+	delegate    http.RoundTripper
+}
+
+func NewEnhanceClusterGatewayRoundTripper(clusterName string) EnhanceClusterGatewayRoundTripper {
+	return &enhanceClusterGatewayRoundTripper{clusterName: clusterName}
+}
+
+func (e *enhanceClusterGatewayRoundTripper) NewRoundTripper(delegate http.RoundTripper) http.RoundTripper {
+	e.delegate = delegate
+	return e
+}
+
+func (e *enhanceClusterGatewayRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.URL.Path = formatProxyURL(e.clusterName, request.URL.Path)
+	return e.delegate.RoundTrip(request)
+}

--- a/pkg/apis/cluster/transport/roundtripper.go
+++ b/pkg/apis/cluster/transport/roundtripper.go
@@ -8,20 +8,6 @@ import (
 	clusterapi "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
 )
 
-func NewClusterGatewayRoundTripper(delegate http.RoundTripper) http.RoundTripper {
-	return &clusterGatewayRoundTripper{
-		delegate: delegate,
-		fallback: true,
-	}
-
-}
-func NewStrictClusterGatewayRoundTripper(delegate http.RoundTripper, fallback bool) http.RoundTripper {
-	return &clusterGatewayRoundTripper{
-		delegate: delegate,
-		fallback: false,
-	}
-}
-
 var _ http.RoundTripper = &clusterGatewayRoundTripper{}
 
 type clusterGatewayRoundTripper struct {
@@ -30,6 +16,20 @@ type clusterGatewayRoundTripper struct {
 	// this is required when the client does implicit api discovery
 	// e.g. controller-runtime client
 	fallback bool
+}
+
+func NewClusterGatewayRoundTripper(delegate http.RoundTripper) http.RoundTripper {
+	return &clusterGatewayRoundTripper{
+		delegate: delegate,
+		fallback: true,
+	}
+}
+
+func NewStrictClusterGatewayRoundTripper(delegate http.RoundTripper, fallback bool) http.RoundTripper {
+	return &clusterGatewayRoundTripper{
+		delegate: delegate,
+		fallback: false,
+	}
 }
 
 func (c *clusterGatewayRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Signed-off-by: champly <champly@outlook.com>

`multicluster.NewClusterGatewayRoundTripper` not support informer cache. Because informerFactory.Start use ctx listen for stop signals. So add enhance rounttripper include clusterName.