### PR TITLE
Fix: allow plain secret use when ocm integration enabled

### DIFF
--- a/pkg/apis/cluster/v1alpha1/clustergateway_types_secret.go
+++ b/pkg/apis/cluster/v1alpha1/clustergateway_types_secret.go
@@ -52,7 +52,7 @@ func (in *ClusterGateway) Get(ctx context.Context, name string, _ *metav1.GetOpt
 			ManagedClusters().
 			Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			return nil, err
+			return convertFromSecret(clusterSecret)
 		}
 		return convertFromManagedClusterAndSecret(managedCluster, clusterSecret)
 	}


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

When `--ocm-integration` enabled, clusters managed by direct secrets are unavailable to provide services. This PR fixes it.