### PR TITLE
Add ManagedCluster informer to improve performance

### DIFF
--- a/pkg/apis/cluster/v1alpha1/clustergateway_health.go
+++ b/pkg/apis/cluster/v1alpha1/clustergateway_health.go
@@ -45,6 +45,10 @@ func (in *ClusterGatewayHealth) Get(ctx context.Context, name string, options *m
 }
 
 func (in *ClusterGatewayHealth) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	if singleton.GetSecretControl() == nil {
+		return nil, false, fmt.Errorf("loopback clients are not inited")
+	}
+
 	latestSecret, err := singleton.GetSecretControl().Get(ctx, name)
 	if err != nil {
 		return nil, false, err

--- a/pkg/apis/cluster/v1alpha1/clustergateway_types_secret.go
+++ b/pkg/apis/cluster/v1alpha1/clustergateway_types_secret.go
@@ -47,10 +47,7 @@ func (in *ClusterGateway) Get(ctx context.Context, name string, _ *metav1.GetOpt
 	}
 
 	if options.OCMIntegration {
-		managedCluster, err := singleton.GetOCMClient().
-			ClusterV1().
-			ManagedClusters().
-			Get(ctx, name, metav1.GetOptions{})
+		managedCluster, err := singleton.GetClusterControl().Get(ctx, name)
 		if err != nil {
 			return convertFromSecret(clusterSecret)
 		}
@@ -74,18 +71,15 @@ func (in *ClusterGateway) List(ctx context.Context, opt *internalversion.ListOpt
 	}
 
 	if options.OCMIntegration {
-		clusters, err := singleton.GetOCMClient().
-			ClusterV1().
-			ManagedClusters().
-			List(context.TODO(), metav1.ListOptions{})
+		clusters, err := singleton.GetClusterControl().List(ctx)
 		if err != nil {
 			return nil, err
 		}
 		clustersByName := make(map[string]*clusterv1.ManagedCluster)
-		for _, cluster := range clusters.Items {
-			cluster := cluster
-			clustersByName[cluster.Name] = &cluster
+		for _, cluster := range clusters {
+			clustersByName[cluster.Name] = cluster
 		}
+
 		for _, secret := range clusterSecrets {
 			if cluster, ok := clustersByName[secret.Name]; ok {
 				gw, err := convertFromManagedClusterAndSecret(cluster, secret)

--- a/pkg/featuregates/featue_gate.go
+++ b/pkg/featuregates/featue_gate.go
@@ -38,10 +38,18 @@ const (
 	// ClientIdentityPenetration enforce impersonate as the original request user
 	// when accessing apiserver in ManagedCluster
 	ClientIdentityPenetration featuregate.Feature = "ClientIdentityPenetration"
+
+	// owner: @ivan-cai
+	// beta: v1.6.0
+	//
+	// SecretCache runs a OCM ManagedCluster informer inside the apiserver which
+	// provides a cache for reading ManagedCluster.
+	OCMClusterCache featuregate.Feature = "OCMClusterCache"
 )
 
 var DefaultKubeFedFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HealthinessCheck:          {Default: false, PreRelease: featuregate.Alpha},
 	SecretCache:               {Default: true, PreRelease: featuregate.Beta},
 	ClientIdentityPenetration: {Default: false, PreRelease: featuregate.Alpha},
+	OCMClusterCache:           {Default: true, PreRelease: featuregate.Beta},
 }

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1,0 +1,65 @@
+package cluster
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	ocmclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterv1Lister "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+type OCMClusterControl interface {
+	Get(ctx context.Context, name string) (*clusterv1.ManagedCluster, error)
+	List(ctx context.Context) ([]*clusterv1.ManagedCluster, error)
+}
+
+var _ OCMClusterControl = &directOCMClusterControl{}
+
+type directOCMClusterControl struct {
+	ocmClient ocmclient.Interface
+}
+
+func NewDirectOCMClusterControl(ocmClient ocmclient.Interface) OCMClusterControl {
+	return &directOCMClusterControl{
+		ocmClient: ocmClient,
+	}
+}
+
+func (c *directOCMClusterControl) Get(ctx context.Context, name string) (*clusterv1.ManagedCluster, error) {
+	return c.ocmClient.ClusterV1().ManagedClusters().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *directOCMClusterControl) List(ctx context.Context) ([]*clusterv1.ManagedCluster, error) {
+	clusterList, err := c.ocmClient.ClusterV1().ManagedClusters().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := make([]*clusterv1.ManagedCluster, len(clusterList.Items))
+	for _, item := range clusters {
+		clusters = append(clusters, item)
+	}
+
+	return clusters, nil
+}
+
+var _ OCMClusterControl = &cacheOCMClusterControl{}
+
+type cacheOCMClusterControl struct {
+	clusterLister clusterv1Lister.ManagedClusterLister
+}
+
+func NewCacheOCMClusterControl(clusterLister clusterv1Lister.ManagedClusterLister) OCMClusterControl {
+	return &cacheOCMClusterControl{
+		clusterLister: clusterLister,
+	}
+}
+
+func (c *cacheOCMClusterControl) Get(ctx context.Context, name string) (*clusterv1.ManagedCluster, error) {
+	return c.clusterLister.Get(name)
+}
+
+func (c *cacheOCMClusterControl) List(ctx context.Context) ([]*clusterv1.ManagedCluster, error) {
+	return c.clusterLister.List(labels.Everything())
+}

--- a/pkg/util/singleton/loopback.go
+++ b/pkg/util/singleton/loopback.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oam-dev/cluster-gateway/pkg/config"
 	"github.com/oam-dev/cluster-gateway/pkg/featuregates"
 	"github.com/oam-dev/cluster-gateway/pkg/util/cert"
+	clusterutil "github.com/oam-dev/cluster-gateway/pkg/util/cluster"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
@@ -16,6 +17,8 @@ import (
 	clientgorest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	ocmclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
+	clusterv1Lister "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 	"sigs.k8s.io/apiserver-runtime/pkg/util/loopback"
 )
 
@@ -26,6 +29,10 @@ var secretInformer cache.SharedIndexInformer
 var secretLister corev1lister.SecretLister
 
 var secretControl cert.SecretControl
+
+var clusterInformer cache.SharedIndexInformer
+var clusterLister clusterv1Lister.ManagedClusterLister
+var clusterControl clusterutil.OCMClusterControl
 
 func GetSecretControl() cert.SecretControl {
 	return secretControl
@@ -60,6 +67,17 @@ func InitLoopbackClient(ctx server.PostStartHookContext) error {
 	if secretControl == nil {
 		secretControl = cert.NewDirectApiSecretControl(config.SecretNamespace, kubeClient)
 	}
+
+	if utilfeature.DefaultMutableFeatureGate.Enabled(featuregates.OCMClusterCache) {
+		if err := setOCMClusterInformer(ocmClient, ctx.StopCh); err != nil {
+			return err
+		}
+		clusterControl = clusterutil.NewCacheOCMClusterControl(clusterLister)
+	}
+	if clusterControl == nil {
+		clusterControl = clusterutil.NewDirectOCMClusterControl(ocmClient)
+	}
+
 	return nil
 }
 
@@ -87,4 +105,18 @@ func SetOCMClient(c ocmclient.Interface) {
 // SetKubeClient is for test only
 func SetKubeClient(k kubernetes.Interface) {
 	kubeClient = k
+}
+
+func setOCMClusterInformer(c ocmclient.Interface, stopCh <-chan struct{}) error {
+	ocmClusterInformers := clusterinformers.NewSharedInformerFactory(c, 0)
+	clusterInformer = ocmClusterInformers.Cluster().V1().ManagedClusters().Informer()
+	clusterLister = ocmClusterInformers.Cluster().V1().ManagedClusters().Lister()
+	go clusterInformer.Run(stopCh)
+	return wait.PollImmediateUntil(time.Second, func() (done bool, err error) {
+		return clusterInformer.HasSynced(), nil
+	}, stopCh)
+}
+
+func GetClusterControl() clusterutil.OCMClusterControl {
+	return clusterControl
 }


### PR DESCRIPTION
We got a higher latency when using cluster-gateway with `ocm-integration=true`  to access managed cluster k8s resources.
And through e2e benchmark test, I found that cluster-gateway will get ManagedCluster per request, and sometimes it will cost X*100ms(sometimes X senconds in the production environment). 
ManagedCluster is not got from cache，so I add ManagedCluster informer to improve performance, and according to the result of e2e benchmark, the latency is greatly reduced.

add arg `--v=4` to gateway-deployment, and then run [multicluster e2e benchmark test case](https://github.com/ivan-cai/cluster-gateway/blob/1.5.0-multicluster-benchmark/e2e/benchmark/configmap.go#L119) test case, I copy the logs of some high latency requests below:
```
I1206 10:22:12.321915       1 request.go:597] Waited for 392.608513ms due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/cluster.open-cluster-management.io/v1/managedclusters/cluster-81
I1206 10:22:12.326916       1 httplog.go:129] "HTTP" verb="GET" URI="/apis/cluster.core.oam.dev/v1alpha1/clustergateways/cluster-81/proxy/api/v1/namespaces/kube-system" latency="398.586785ms" userAgent="Go-http-client/2.0" audit-ID="94579a16-45ba-4333-8c83-7bb95dd703ea" srcIP="172.23.211.87:58464" resp=200
I1206 10:22:12.522535       1 request.go:597] Waited for 387.186395ms due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/cluster.open-cluster-management.io/v1/managedclusters/cluster-82
I1206 10:22:12.526706       1 httplog.go:129] "HTTP" verb="GET" URI="/apis/cluster.core.oam.dev/v1alpha1/clustergateways/cluster-82/proxy/healthz" latency="391.656812ms" userAgent="Go-http-client/2.0" audit-ID="1e02f8f4-8bcd-4fdb-a96d-978074d2f0c5" srcIP="172.23.211.88:36280" resp=200
I1206 10:22:12.722840       1 request.go:597] Waited for 382.323062ms due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/cluster.open-cluster-management.io/v1/managedclusters/cluster-77
I1206 10:22:12.727957       1 httplog.go:129] "HTTP" verb="GET" URI="/apis/cluster.core.oam.dev/v1alpha1/clustergateways/cluster-77/proxy/api/v1/namespaces/kube-system" latency="387.744393ms" userAgent="Go-http-client/2.0" audit-ID="5022a7df-d6e8-48a7-a53a-2901cc15f187" srcIP="172.23.211.87:58464" resp=200
I1206 10:22:12.922070       1 request.go:597] Waited for 387.643281ms due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/cluster.open-cluster-management.io/v1/managedclusters/cluster-80
I1206 10:22:12.926795       1 httplog.go:129] "HTTP" verb="GET" URI="/apis/cluster.core.oam.dev/v1alpha1/clustergateways/cluster-80/proxy/healthz" latency="393.948768ms" userAgent="Go-http-client/2.0" audit-ID="ac30211c-7c27-45f2-97b8-c6885826022b" srcIP="172.23.211.88:36280" resp=200
I1206 10:22:13.122193       1 request.go:597] Waited for 392.955174ms due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/cluster.open-cluster-management.io/v1/managedclusters/cluster-78
I1206 10:22:13.126164       1 httplog.go:129] "HTTP" verb="GET" URI="/apis/cluster.core.oam.dev/v1alpha1/clustergateways/cluster-78/proxy/api/v1/namespaces/kube-system" latency="397.184533ms" userAgent="Go-http-client/2.0" audit-ID="5a27ffae-58d2-4b63-badf-4c6d832bc8e9" srcIP="172.23.211.87:58464" resp=200
```

the result of e2e benchmark before adding ManagedCluster informer:
```
• [MEASUREMENT]
Basic RoundTrip Test
/root/cluster-gateway/e2e/benchmark/configmap.go:32
  list namespace from managed cluster
  /root/cluster-gateway/e2e/benchmark/configmap.go:143

  Ran 10 samples:
  runtime:
    Fastest Time: 0.384s
    Slowest Time: 1.212s
    Average Time: 0.921s ± 0.311s
------------------------------

Ran 1 of 1 Specs in 9.210 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

You're using deprecated Ginkgo functionality:
=============================================
Ginkgo 2.0 is under active development and will introduce several new features, improvements, and a small handful of breaking changes.
A release candidate for 2.0 is now available and 2.0 should GA in Fall 2021.  Please give the RC a try and send us feedback!
  - To learn more, view the migration guide at https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md
  - For instructions on using the Release Candidate visit https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#using-the-beta
  - To comment, chime in at https://github.com/onsi/ginkgo/issues/711

  Measure is deprecated and will be removed in Ginkgo V2.  Please migrate to gomega/gmeasure.
  Learn more at: https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#removed-measure
    /root/cluster-gateway/e2e/benchmark/configmap.go:143

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=1.16.5

--- PASS: TestE2E (9.23s)
PASS
ok  	github.com/oam-dev/cluster-gateway/e2e/benchmark	9.250s
```

the result of e2e benchmark after adding ManagedCluster informer:
```
• [MEASUREMENT]
Basic RoundTrip Test
/root/cluster-gateway/e2e/benchmark/configmap.go:32
  list namespace from managed cluster
  /root/cluster-gateway/e2e/benchmark/configmap.go:143

  Ran 10 samples:
  runtime:
    Fastest Time: 0.020s
    Slowest Time: 0.058s
    Average Time: 0.025s ± 0.011s
------------------------------

Ran 1 of 1 Specs in 0.250 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

You're using deprecated Ginkgo functionality:
=============================================
Ginkgo 2.0 is under active development and will introduce several new features, improvements, and a small handful of breaking changes.
A release candidate for 2.0 is now available and 2.0 should GA in Fall 2021.  Please give the RC a try and send us feedback!
  - To learn more, view the migration guide at https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md
  - For instructions on using the Release Candidate visit https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#using-the-beta
  - To comment, chime in at https://github.com/onsi/ginkgo/issues/711

  Measure is deprecated and will be removed in Ginkgo V2.  Please migrate to gomega/gmeasure.
  Learn more at: https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#removed-measure
    /root/cluster-gateway/e2e/benchmark/configmap.go:143

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=1.16.5

--- PASS: TestE2E (0.26s)
PASS
ok  	github.com/oam-dev/cluster-gateway/e2e/benchmark	0.286s
```
