### PR TITLE
Feat: support proxy dryrun request

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -69,6 +69,10 @@ func main() {
 			}
 			return options
 		}).
+		WithServerFns(func(server *builder.GenericAPIServer) *builder.GenericAPIServer {
+			server.Handler.FullHandlerChain = clusterv1alpha1.NewClusterGatewayProxyRequestEscaper(server.Handler.FullHandlerChain)
+			return server
+		}).
 		WithPostStartHook("init-master-loopback-client", singleton.InitLoopbackClient).
 		Build()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

In Kubernetes apiserver lib, the dryRun request for rest.Connector will be filtered which means ClusterGateway cannot make proxy request for dryRun request previously. This PR solves this issue by
1. Escape the dryRun query parameter to __dryRun at the beginning of handling proxy requests.
2. Unescape it while making proxy requests.

https://github.com/kubernetes/kubernetes/blob/b0246c64309ce1ce504ae0a2ca3c66be6ff814e5/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go#L181