### PR TITLE
feat: allow `.` in proxy path escape pattern

### DIFF
--- a/pkg/apis/cluster/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/cluster/v1alpha1/clustergateway_proxy.go
@@ -379,7 +379,7 @@ var (
 		config.MetaApiGroupName,
 		config.MetaApiVersionName,
 		"clustergateways",
-		"[a-z0-9]([-a-z0-9]*[a-z0-9])?",
+		"[a-z0-9]([-.a-z0-9]*[a-z0-9])?",
 		"proxy"}, "/"))
 	clusterGatewayProxyQueryKeysToEscape = []string{"dryRun"}
 	clusterGatewayProxyEscaperPrefix     = "__"


### PR DESCRIPTION
Add the `.` character to the proxy path escape pattern so that we can use e.g. domain names as cluster names without breaking the query parameters escaping.

See https://github.com/oam-dev/cluster-gateway/issues/150