### PR TITLE
Use `CreateSingleUseGrpcTunnelWithContext` and set keepAlive.time to 20 seconds

### DIFF
--- a/pkg/apis/cluster/v1alpha1/transport.go
+++ b/pkg/apis/cluster/v1alpha1/transport.go
@@ -30,12 +30,13 @@ var DialerGetter = func(ctx context.Context) (k8snet.DialFunc, error) {
 	if err != nil {
 		return nil, err
 	}
-	dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
+	dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnelWithContext(
 		ctx,
+		context.Background(),
 		net.JoinHostPort(config.ClusterProxyHost, strconv.Itoa(config.ClusterProxyPort)),
 		grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time: time.Second * 5,
+			Time: 20 * time.Second,
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
Refactored to use `CreateSingleUseGrpcTunnelWithContext` for tunnel creation and set gRPC keep-alive time to 20 seconds. The previous value of 5 seconds caused excessive pings, leading to unnecessary overhead.