### PR TITLE
Chore: increase test time out 

### DIFF
--- a/e2e/ocm/clustergateway.go
+++ b/e2e/ocm/clustergateway.go
@@ -54,7 +54,7 @@ var _ = Describe("Addon Manager Test", func() {
 					gwHealthy := gw.Status.Healthy
 					return addonHealthy && gwHealthy, nil
 				}).
-				WithTimeout(time.Minute).
+				WithTimeout(5 * time.Minute).
 				Should(BeTrue())
 		})
 	It("Manual probe healthiness should work",

--- a/e2e/ocm/clustergateway.go
+++ b/e2e/ocm/clustergateway.go
@@ -54,7 +54,7 @@ var _ = Describe("Addon Manager Test", func() {
 					gwHealthy := gw.Status.Healthy
 					return addonHealthy && gwHealthy, nil
 				}).
-				WithTimeout(5 * time.Minute).
+				WithTimeout(10 * time.Minute).
 				Should(BeTrue())
 		})
 	It("Manual probe healthiness should work",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increased the test timeout in clustergateway.go from 1 minute to 5 minutes to prevent test failures due to slow responses.

<!-- End of auto-generated description by cubic. -->

