### PR TITLE
debugging ocm failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,7 @@ jobs:
           node_image: kindest/node:v1.31.9
       - name: Prepare OCM testing environment
         run: |
+          set -ex
           clusteradm init --output-join-command-file join.sh --wait
           sh -c "$(cat join.sh) loopback --force-internal-endpoint-lookup"
           clusteradm accept --clusters loopback --wait 30
@@ -167,4 +168,5 @@ jobs:
           kubectl wait --for=condition=Available apiservice/v1alpha1.cluster.core.oam.dev
       - name: Run e2e test
         run: |
+          set -ex
           make test-e2e-ocm

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bin
 # Kubernetes Generated files - skip generated files, except for vendored files
 
 !vendor/**/zz_generated.*
+join.sh
 
 # editor and IDE paraphernalia
 .idea


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added debug flags to OCM test steps and updated .gitignore to exclude join.sh.

<!-- End of auto-generated description by cubic. -->

